### PR TITLE
Fix invalid formatting of idf_component.yml to allow build

### DIFF
--- a/examples/Box-3_LVGL9_Demo/main/idf_component.yml
+++ b/examples/Box-3_LVGL9_Demo/main/idf_component.yml
@@ -2,8 +2,8 @@
 dependencies:
   espressif/esp-box-3: "^1.2.0~2"
   jmattsson/esp-picotts:
-  version: "==1.*"
-  override_path: "../../../"
+    version: "==1.*"
+    override_path: "../../../"
   ## Required IDF version
   idf:
     version: ">=5.1.0"


### PR DESCRIPTION
IDF complained about invalid syntax until I tabbed the following lines:

```yaml
    version: "==1.*"
    override_path: "../../../"
```
